### PR TITLE
Added maven dependency details to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ cd nlapi-java
 ./gradlew distZip    
 ```
 
+## Add maven dependency
+
+```
+<dependency>
+    <groupId>ai.expert</groupId>
+    <artifactId>nlapi-java-sdk</artifactId>
+    <version>2.1.2</version>
+</dependency>
+
+```
+
 
 ## Setting your credentials
 


### PR DESCRIPTION
The SDK can't actually be added to another project without the maven dependency. 